### PR TITLE
Fix weird `directory ... not found`

### DIFF
--- a/plugin/jump.vim
+++ b/plugin/jump.vim
@@ -30,7 +30,7 @@ function! s:JumpGuard()
 endfunction
 
 function! s:JumpCommand(cmd, args)
-  return system("sh -c 'source " . g:autojump_executable . " && " . a:cmd . " " . a:args . " > /dev/null && pwd'")
+  return system("bash -c 'source " . g:autojump_executable . " && " . a:cmd . " " . a:args . " > /dev/null && pwd'")
 endfunction
 
 function! s:JumpExtractArgs(rawArgs)


### PR DESCRIPTION
Hi @padde thank you very much for the amazing plugin!
I have being using it for a while now, but in the last weeks when I switched operating system, I have been dealing with a very weird `directory ... not found error` (when the directory does exist).

It turns out, some OSs have `sh` linked to other kinds of shells, that are not
`bash`-like. For example, Ubuntu uses `dash` (ref: https://wiki.ubuntu.com/DashAsBinSh).

Some of those shells do not provide the built-in command `source`, which causes
the function `JumpCommand` to fail with an 127 error code.

Since `jump.vim` assumes all errors are caused by non-existing directories,
the resulting error message was very enigmatic and frustrating…

This PR, tries to solve that by enforcing `bash`, that is pretty much present every where. While it is not ideal to assume `bash` is omnipresent, we cannot assume all built-in `sh` support the `source` command either :(
This would be the best compromise I think (especially considering for example that Ubuntu is quite popular).